### PR TITLE
Remove note on symbols and improve testing instructions

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -577,7 +577,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 * 1a. The list is empty.
 
-       Use case ends.
+    Use case ends.
 
 * 2a. The given client index is invalid.
 
@@ -585,7 +585,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     * 2a2. User inputs in the client index again.
     * 2a3. Repeat steps 2a1-2a2 until the input is a valid index.
 
-          Use case resumes at step 3.
+       Use case resumes at step 3.
 
 ### **Use case: UC05 - List all saved clients**
 
@@ -684,7 +684,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 6.  Should be stable and dependable, minimizing the risk of crashes or data loss, and ensuring that appointments and client information are accurately stored and retrieved.
 7.  Should be able to accommodate the growing number of clients and appointments without a significant decrease in performance or usability.
 
-*{More to be added}*
 
 ### Glossary
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -299,8 +299,7 @@ The date and time of `from` and `to` are stored in `LocalDateTime` and truncated
 
 <div markdown="span" class="alert alert-info">
 :information_source:
-Note: The red square is PlantUML for `private` access modifier. <br>
-Details not relevant to the appointments scheduling functionality is omitted.
+Note: Details not relevant to the appointments scheduling functionality is omitted.
 </div>
 
 [//]: # (### \[Proposed\] Undo/redo feature)

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -750,7 +750,10 @@ testers are expected to do more *exploratory* testing.
 
 1. Run through the entire new user tutorial [in `User Guide > Quick Start > New User Tutorial`](https://ay2324s2-cs2103t-t17-1.github.io/tp/UserGuide.html#new-user-tutorial).
 
-2. The guide will take you through all essential features of SWEE.
+   1. The guide will take you through all essential features of SWEE.
+   2. Each section can exist as a self-contained test case of a feature.
+   3. Each section give a brief overview of what to expect.
+   4. Expected: Successful running of all valid commands demonstrated in the User Guide.
 
 [//]: # (### Saving data)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -488,7 +488,7 @@ Schedules an appointment for a client.
 
 Format: `sched INDEX --title=TITLE --from=START --to=END --addr=ADDRESS `
 
-* The `INDEX` must be a positive integer.
+* The `INDEX` must be a positive integer and a valid client index.
 * The `START` and `END` dates/times must be in the format `dd/MM/yyyy HH:mm`.
 * The `END` date/time should not be earlier than, but can be equal to the `START` date/time.
 * It is possible to add appointments whose `START` and `END` times have already passed (for record-keeping purposes).
@@ -518,7 +518,7 @@ Unschedules an appointment for a client.
 Format: `unsched INDEX --appt=APPT_INDEX`
 
 * `APPT_INDEX` refers to the index of the appointment for that specific client.
-* The `INDEX` and `APPT_INDEX` must be positive integers.
+* The `INDEX` and `APPT_INDEX` must be positive integers and valid indexes of the client and appointment respectively.
 
 Example:
 * `unsched 1 --appt=2` unschedules the appointment at index 2 for the client at index 1.<br>


### PR DESCRIPTION
Since we no longer use symbol we do not need the note on the custom symbols